### PR TITLE
Bump peer dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ exports.register = function (server, options, next) {
 
 
   // hook into hapi default logging events
-  server.on('internalError', Api.logReqError.bind(Rollbar));
+  server.on('request-error', Api.logReqError.bind(Rollbar));
 
   server.on('request', (request, event, tags) => {
     if (!event || event.internal) return;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint": "^2.12.0"
   },
   "peerDependencies": {
-    "hapi": "13.x.x",
+    "hapi": "15.x.x",
     "rollbar": "0.6.x"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "eslint": "^2.12.0"
   },
   "peerDependencies": {
-    "hapi": "15.x.x",
-    "rollbar": "0.6.x"
+    "hapi": "16.x.x",
+    "rollbar": "2.1.x"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
Bump hapi peer dependencies to version 16.x.x and rollbar to version 2.x.x